### PR TITLE
feat: add support for blocking

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ outputs:
   run_status:
     description: 'The final status of the run (INITIATED, RUNNING, COMPLETED, ERROR, or CANCELLED). Only set when blocking is true.'
   run_result:
-    description: 'The test execution result (PASSED, FAILED, or SKIPPED). Only set when blocking is true and status is COMPLETED.'
+    description: 'The test execution result (PASSED, FAILED, or SKIPPED). Only set when blocking is true.'
   run_short_id:
     description: 'The short ID of the run.'
 

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,13 @@ inputs:
     default: 'false'
 
 outputs:
-  success:
-    description: 'Whether the run was created successfully.'
-  runShortId:
+  run_created:
+    description: 'Whether the test run was created successfully on QA.tech.'
+  run_status:
+    description: 'The final status of the run (INITIATED, RUNNING, COMPLETED, ERROR, or CANCELLED). Only set when blocking is true.'
+  run_result:
+    description: 'The test execution result (PASSED, FAILED, or SKIPPED). Only set when blocking is true and status is COMPLETED.'
+  run_short_id:
     description: 'The short ID of the run.'
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   test_plan_short_ids:
     description: 'The test plan IDs to run the tests in.'
     required: false
+  blocking:
+    description: 'Whether the run should be blocking.'
+    required: false
+    default: 'false'
 
 outputs:
   success:

--- a/dist/index.js
+++ b/dist/index.js
@@ -39401,8 +39401,9 @@ async function run() {
             core.setOutput("run_created", "true");
             core.setOutput("run_short_id", result.run.shortId);
             core.info(`QA.tech run started with ID: ${result.run.id}, Short ID: ${result.run.shortId}`);
+            core.info(`View run at: ${result.run.url}`);
             if (blocking) {
-                core.info("Waiting for test results...");
+                core.info(`Waiting for test results... (${result.run.url})`);
                 while (true) {
                     const status = await getRunStatus(baseApiUrl, projectId, result.run.shortId, apiToken);
                     core.info(`Current status: ${status.status}, Result: ${status.result || "pending"}`);
@@ -39410,21 +39411,21 @@ async function run() {
                         core.setOutput("run_status", status.status);
                         core.setOutput("run_result", status.result);
                         if (status.result === "FAILED") {
-                            core.setFailed("Test run failed");
+                            core.setFailed(`Test run failed. View results at: ${result.run.url}`);
                             return;
                         }
                         if (status.result === "PASSED") {
-                            core.info("Test run completed successfully");
+                            core.info(`Test run completed successfully. View results at: ${result.run.url}`);
                             return;
                         }
                         if (status.result === "SKIPPED") {
-                            core.warning("Test run was skipped");
+                            core.warning(`Test run was skipped. View details at: ${result.run.url}`);
                             return;
                         }
                     }
                     if (status.status === "ERROR" || status.status === "CANCELLED") {
                         core.setOutput("run_status", status.status);
-                        core.setFailed(`Test run ${status.status.toLowerCase()}`);
+                        core.setFailed(`Run ${status.status.toLowerCase()}. View details at: ${result.run.url}`);
                         return;
                     }
                     // If still running or initiated, wait and check again

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"keywords": ["QA", "actions", "QA.tech"],
 	"author": "QA Tech AB",
 	"license": "MIT",
-	"packageManager": "pnpm@9.13.2",
+	"packageManager": "pnpm@9.15.0",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@types/node": "^22.10.7",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,345 +7,345 @@ import { run } from "../index";
 
 vi.mock("@actions/core");
 vi.mock("../api-client", () => ({
-  triggerQATechRun: vi.fn(),
-  getRunStatus: vi.fn(),
+	triggerQATechRun: vi.fn(),
+	getRunStatus: vi.fn(),
 }));
 vi.mock("@actions/github", () => ({
-  default: vi.fn(),
-  context: {
-    actor: "testUser",
-    ref: "refs/heads/main",
-    sha: "abc123",
-    repo: {
-      owner: "test-owner",
-      repo: "test-repo",
-    },
-  } as typeof github.context,
+	default: vi.fn(),
+	context: {
+		actor: "testUser",
+		ref: "refs/heads/main",
+		sha: "abc123",
+		repo: {
+			owner: "test-owner",
+			repo: "test-repo",
+		},
+	} as typeof github.context,
 }));
 
 describe("GitHub Action", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+	beforeEach(() => {
+		vi.clearAllMocks();
 
-    // Default core.getInput mock implementation
-    vi.mocked(core.getInput).mockImplementation((name) => {
-      switch (name) {
-        case "project_id":
-          return "test-project";
-        case "api_token":
-          return "test-token-12345";
-        case "api_url":
-          return "";
-        case "test_plan_short_ids":
-          return "";
-        default:
-          return "";
-      }
-    });
-  });
+		// Default core.getInput mock implementation
+		vi.mocked(core.getInput).mockImplementation((name) => {
+			switch (name) {
+				case "project_id":
+					return "test-project";
+				case "api_token":
+					return "test-token-12345";
+				case "api_url":
+					return "";
+				case "test_plan_short_ids":
+					return "";
+				default:
+					return "";
+			}
+		});
+	});
 
-  it("should successfully start a run and set run outputs", async () => {
-    const mockRunResponse = {
-      run: {
-        id: "test-id",
-        shortId: "short-id",
-      },
-    };
+	it("should successfully start a run and set run outputs", async () => {
+		const mockRunResponse = {
+			run: {
+				id: "test-id",
+				shortId: "short-id",
+			},
+		};
 
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-    await run();
+		await run();
 
-    expect(triggerQATechRun).toHaveBeenCalledWith(
-      "https://app.qa.tech/api/projects/test-project/runs",
-      "test-token-12345",
-      {
-        trigger: "GITHUB",
-        actor: "testUser",
-        branch: "refs/heads/main",
-        commitHash: "abc123",
-        repository: "test-repo",
-      }
-    );
-    expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
-    expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
-    expect(core.setFailed).not.toHaveBeenCalled();
-  });
+		expect(triggerQATechRun).toHaveBeenCalledWith(
+			"https://app.qa.tech/api/projects/test-project/runs",
+			"test-token-12345",
+			{
+				trigger: "GITHUB",
+				actor: "testUser",
+				branch: "refs/heads/main",
+				commitHash: "abc123",
+				repository: "test-repo",
+			},
+		);
+		expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
+		expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
+		expect(core.setFailed).not.toHaveBeenCalled();
+	});
 
-  it("should handle failed run creation", async () => {
-    const mockRunResponse = {};
+	it("should handle failed run creation", async () => {
+		const mockRunResponse = {};
 
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-    await run();
+		await run();
 
-    expect(core.setOutput).toHaveBeenCalledWith("run_created", "false");
-    expect(core.setFailed).toHaveBeenCalledWith(
-      "No run details returned from API"
-    );
-  });
+		expect(core.setOutput).toHaveBeenCalledWith("run_created", "false");
+		expect(core.setFailed).toHaveBeenCalledWith(
+			"No run details returned from API",
+		);
+	});
 
-  it("should successfully start a run with test plans", async () => {
-    const testPlans = "plan1,plan2, plan3";
-    vi.mocked(core.getInput).mockImplementation((name) => {
-      switch (name) {
-        case "test_plan_short_ids":
-          return testPlans;
-        case "project_id":
-          return "test-project";
-        case "api_token":
-          return "test-token-12345";
-        default:
-          return "";
-      }
-    });
+	it("should successfully start a run with test plans", async () => {
+		const testPlans = "plan1,plan2, plan3";
+		vi.mocked(core.getInput).mockImplementation((name) => {
+			switch (name) {
+				case "test_plan_short_ids":
+					return testPlans;
+				case "project_id":
+					return "test-project";
+				case "api_token":
+					return "test-token-12345";
+				default:
+					return "";
+			}
+		});
 
-    const mockRunResponse = {
-      run: {
-        id: "test-id",
-        shortId: "short-id",
-      },
-    };
+		const mockRunResponse = {
+			run: {
+				id: "test-id",
+				shortId: "short-id",
+			},
+		};
 
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-    await run();
+		await run();
 
-    expect(triggerQATechRun).toHaveBeenCalledWith(
-      "https://app.qa.tech/api/projects/test-project/runs",
-      "test-token-12345",
-      expect.objectContaining({
-        testPlanShortIds: ["plan1", "plan2", "plan3"],
-      })
-    );
-  });
+		expect(triggerQATechRun).toHaveBeenCalledWith(
+			"https://app.qa.tech/api/projects/test-project/runs",
+			"test-token-12345",
+			expect.objectContaining({
+				testPlanShortIds: ["plan1", "plan2", "plan3"],
+			}),
+		);
+	});
 
-  it("should fail when API URL is invalid", async () => {
-    vi.mocked(core.getInput).mockImplementation((name) => {
-      switch (name) {
-        case "api_url":
-          return "invalid-url";
-        case "project_id":
-          return "test-project";
-        case "api_token":
-          return "test-token-12345";
-        default:
-          return "";
-      }
-    });
+	it("should fail when API URL is invalid", async () => {
+		vi.mocked(core.getInput).mockImplementation((name) => {
+			switch (name) {
+				case "api_url":
+					return "invalid-url";
+				case "project_id":
+					return "test-project";
+				case "api_token":
+					return "test-token-12345";
+				default:
+					return "";
+			}
+		});
 
-    await run();
+		await run();
 
-    expect(core.setFailed).toHaveBeenCalledWith("Invalid API URL: invalid-url");
-    expect(triggerQATechRun).not.toHaveBeenCalled();
-  });
+		expect(core.setFailed).toHaveBeenCalledWith("Invalid API URL: invalid-url");
+		expect(triggerQATechRun).not.toHaveBeenCalled();
+	});
 
-  it("should handle empty test plan IDs", async () => {
-    const mockRunResponse = {
-      run: {
-        id: "test-id",
-        shortId: "short-id",
-      },
-    };
+	it("should handle empty test plan IDs", async () => {
+		const mockRunResponse = {
+			run: {
+				id: "test-id",
+				shortId: "short-id",
+			},
+		};
 
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-    await run();
+		await run();
 
-    expect(triggerQATechRun).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      expect.not.objectContaining({
-        testPlanShortIds: expect.anything(),
-      })
-    );
-  });
+		expect(triggerQATechRun).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.any(String),
+			expect.not.objectContaining({
+				testPlanShortIds: expect.anything(),
+			}),
+		);
+	});
 
-  it("should handle malformed test plan IDs", async () => {
-    vi.mocked(core.getInput).mockImplementation((name) => {
-      switch (name) {
-        case "test_plan_short_ids":
-          return ",,test1,,test2,,";
-        case "project_id":
-          return "test-project";
-        case "api_token":
-          return "test-token-12345";
-        default:
-          return "";
-      }
-    });
+	it("should handle malformed test plan IDs", async () => {
+		vi.mocked(core.getInput).mockImplementation((name) => {
+			switch (name) {
+				case "test_plan_short_ids":
+					return ",,test1,,test2,,";
+				case "project_id":
+					return "test-project";
+				case "api_token":
+					return "test-token-12345";
+				default:
+					return "";
+			}
+		});
 
-    const mockRunResponse = {
-      run: {
-        id: "test-id",
-        shortId: "short-id",
-      },
-    };
+		const mockRunResponse = {
+			run: {
+				id: "test-id",
+				shortId: "short-id",
+			},
+		};
 
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-    await run();
+		await run();
 
-    expect(triggerQATechRun).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      expect.objectContaining({
-        testPlanShortIds: ["test1", "test2"],
-      })
-    );
-  });
+		expect(triggerQATechRun).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.any(String),
+			expect.objectContaining({
+				testPlanShortIds: ["test1", "test2"],
+			}),
+		);
+	});
 
-  it("should handle HTTP 400 error", async () => {
-    const errorResponse = new Error("HTTP error! status: 400 - Bad Request");
-    vi.mocked(triggerQATechRun).mockRejectedValueOnce(errorResponse);
+	it("should handle HTTP 400 error", async () => {
+		const errorResponse = new Error("HTTP error! status: 400 - Bad Request");
+		vi.mocked(triggerQATechRun).mockRejectedValueOnce(errorResponse);
 
-    await run();
+		await run();
 
-    expect(core.setFailed).toHaveBeenCalledWith(
-      "Action failed: HTTP error! status: 400 - Bad Request"
-    );
-  });
+		expect(core.setFailed).toHaveBeenCalledWith(
+			"Action failed: HTTP error! status: 400 - Bad Request",
+		);
+	});
 
-  it("should fail when project_id is missing", async () => {
-    vi.mocked(core.getInput).mockImplementation((name, options) => {
-      if (name === "project_id" && options?.required) {
-        throw new Error("Input required and not supplied: project_id");
-      }
-      return name === "api_token" ? "test-token" : "";
-    });
+	it("should fail when project_id is missing", async () => {
+		vi.mocked(core.getInput).mockImplementation((name, options) => {
+			if (name === "project_id" && options?.required) {
+				throw new Error("Input required and not supplied: project_id");
+			}
+			return name === "api_token" ? "test-token" : "";
+		});
 
-    await run();
+		await run();
 
-    expect(core.setFailed).toHaveBeenCalledWith(
-      "Action failed: Input required and not supplied: project_id"
-    );
-    expect(triggerQATechRun).not.toHaveBeenCalled();
-  });
+		expect(core.setFailed).toHaveBeenCalledWith(
+			"Action failed: Input required and not supplied: project_id",
+		);
+		expect(triggerQATechRun).not.toHaveBeenCalled();
+	});
 
-  it("should fail when api_token is missing", async () => {
-    vi.mocked(core.getInput).mockImplementation((name, options) => {
-      if (name === "api_token" && options?.required) {
-        throw new Error("Input required and not supplied: api_token");
-      }
-      return name === "project_id" ? "test-project" : "";
-    });
+	it("should fail when api_token is missing", async () => {
+		vi.mocked(core.getInput).mockImplementation((name, options) => {
+			if (name === "api_token" && options?.required) {
+				throw new Error("Input required and not supplied: api_token");
+			}
+			return name === "project_id" ? "test-project" : "";
+		});
 
-    await run();
+		await run();
 
-    expect(core.setFailed).toHaveBeenCalledWith(
-      "Action failed: Input required and not supplied: api_token"
-    );
-    expect(triggerQATechRun).not.toHaveBeenCalled();
-  });
+		expect(core.setFailed).toHaveBeenCalledWith(
+			"Action failed: Input required and not supplied: api_token",
+		);
+		expect(triggerQATechRun).not.toHaveBeenCalled();
+	});
 
-  it("should handle API errors", async () => {
-    const error = new Error("API Error");
-    vi.mocked(triggerQATechRun).mockRejectedValueOnce(error);
+	it("should handle API errors", async () => {
+		const error = new Error("API Error");
+		vi.mocked(triggerQATechRun).mockRejectedValueOnce(error);
 
-    await run();
+		await run();
 
-    expect(core.setFailed).toHaveBeenCalledWith("Action failed: API Error");
-  });
+		expect(core.setFailed).toHaveBeenCalledWith("Action failed: API Error");
+	});
 
-  it("should handle unknown errors", async () => {
-    vi.mocked(triggerQATechRun).mockRejectedValueOnce("unknown error");
+	it("should handle unknown errors", async () => {
+		vi.mocked(triggerQATechRun).mockRejectedValueOnce("unknown error");
 
-    await run();
+		await run();
 
-    expect(core.setFailed).toHaveBeenCalledWith("An unexpected error occurred");
-  });
+		expect(core.setFailed).toHaveBeenCalledWith("An unexpected error occurred");
+	});
 
-  it("should use custom API URL when provided", async () => {
-    const customApiUrl = "https://custom.qa.tech";
-    vi.mocked(core.getInput).mockImplementation((name) => {
-      switch (name) {
-        case "api_url":
-          return customApiUrl;
-        case "project_id":
-          return "test-project";
-        case "api_token":
-          return "test-token-12345";
-        default:
-          return "";
-      }
-    });
+	it("should use custom API URL when provided", async () => {
+		const customApiUrl = "https://custom.qa.tech";
+		vi.mocked(core.getInput).mockImplementation((name) => {
+			switch (name) {
+				case "api_url":
+					return customApiUrl;
+				case "project_id":
+					return "test-project";
+				case "api_token":
+					return "test-token-12345";
+				default:
+					return "";
+			}
+		});
 
-    const mockRunResponse = {
-      run: {
-        id: "test-id",
-        shortId: "short-id",
-      },
-    };
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		const mockRunResponse = {
+			run: {
+				id: "test-id",
+				shortId: "short-id",
+			},
+		};
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-    await run();
+		await run();
 
-    expect(triggerQATechRun).toHaveBeenCalledWith(
-      `${customApiUrl}/api/projects/test-project/runs`,
-      "test-token-12345",
-      expect.any(Object)
-    );
-  });
+		expect(triggerQATechRun).toHaveBeenCalledWith(
+			`${customApiUrl}/api/projects/test-project/runs`,
+			"test-token-12345",
+			expect.any(Object),
+		);
+	});
 
-  it("should handle blocking mode with successful completion", async () => {
-    vi.mocked(core.getBooleanInput).mockImplementation((name) => {
-      return name === "blocking";
-    });
+	it("should handle blocking mode with successful completion", async () => {
+		vi.mocked(core.getBooleanInput).mockImplementation((name) => {
+			return name === "blocking";
+		});
 
-    const mockRunResponse = {
-      run: {
-        id: "test-id",
-        shortId: "short-id",
-      },
-    };
+		const mockRunResponse = {
+			run: {
+				id: "test-id",
+				shortId: "short-id",
+			},
+		};
 
-    const mockStatusResponse = {
-      id: "test-id",
-      short_id: "short-id",
-      status: "COMPLETED" as const,
-      result: "PASSED" as const,
-    };
+		const mockStatusResponse = {
+			id: "test-id",
+			short_id: "short-id",
+			status: "COMPLETED" as const,
+			result: "PASSED" as const,
+		};
 
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
-    vi.mocked(getRunStatus).mockResolvedValueOnce(mockStatusResponse);
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		vi.mocked(getRunStatus).mockResolvedValueOnce(mockStatusResponse);
 
-    await run();
+		await run();
 
-    expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
-    expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
-    expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
-    expect(core.setOutput).toHaveBeenCalledWith("run_result", "PASSED");
-    expect(core.setFailed).not.toHaveBeenCalled();
-  });
+		expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
+		expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
+		expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
+		expect(core.setOutput).toHaveBeenCalledWith("run_result", "PASSED");
+		expect(core.setFailed).not.toHaveBeenCalled();
+	});
 
-  it("should handle blocking mode with failed completion", async () => {
-    vi.mocked(core.getBooleanInput).mockImplementation((name) => {
-      return name === "blocking";
-    });
+	it("should handle blocking mode with failed completion", async () => {
+		vi.mocked(core.getBooleanInput).mockImplementation((name) => {
+			return name === "blocking";
+		});
 
-    const mockRunResponse = {
-      run: {
-        id: "test-id",
-        shortId: "short-id",
-      },
-    };
+		const mockRunResponse = {
+			run: {
+				id: "test-id",
+				shortId: "short-id",
+			},
+		};
 
-    const mockStatusResponse = {
-      id: "test-id",
-      short_id: "short-id",
-      status: "COMPLETED" as const,
-      result: "FAILED" as const,
-    };
+		const mockStatusResponse = {
+			id: "test-id",
+			short_id: "short-id",
+			status: "COMPLETED" as const,
+			result: "FAILED" as const,
+		};
 
-    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
-    vi.mocked(getRunStatus).mockResolvedValueOnce(mockStatusResponse);
+		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+		vi.mocked(getRunStatus).mockResolvedValueOnce(mockStatusResponse);
 
-    await run();
+		await run();
 
-    expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
-    expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
-    expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
-    expect(core.setOutput).toHaveBeenCalledWith("run_result", "FAILED");
-    expect(core.setFailed).toHaveBeenCalledWith("Test run failed");
-  });
+		expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
+		expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
+		expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
+		expect(core.setOutput).toHaveBeenCalledWith("run_result", "FAILED");
+		expect(core.setFailed).toHaveBeenCalledWith("Test run failed");
+	});
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -49,6 +49,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 
@@ -69,6 +70,11 @@ describe("GitHub Action", () => {
 		);
 		expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
 		expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
+		expect(core.info).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"View run at: https://app.qa.tech/dashboard/p/test-project/results/short-id",
+			),
+		);
 		expect(core.setFailed).not.toHaveBeenCalled();
 	});
 
@@ -104,6 +110,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 
@@ -145,6 +152,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 
@@ -179,6 +187,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 
@@ -274,6 +283,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
@@ -296,6 +306,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 
@@ -315,6 +326,11 @@ describe("GitHub Action", () => {
 		expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
 		expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
 		expect(core.setOutput).toHaveBeenCalledWith("run_result", "PASSED");
+		expect(core.info).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Test run completed successfully. View results at:",
+			),
+		);
 		expect(core.setFailed).not.toHaveBeenCalled();
 	});
 
@@ -327,6 +343,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 
@@ -346,7 +363,9 @@ describe("GitHub Action", () => {
 		expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
 		expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
 		expect(core.setOutput).toHaveBeenCalledWith("run_result", "FAILED");
-		expect(core.setFailed).toHaveBeenCalledWith("Test run failed");
+		expect(core.setFailed).toHaveBeenCalledWith(
+			expect.stringContaining("Test run failed. View results at:"),
+		);
 	});
 
 	it("should poll status updates in blocking mode until completion", async () => {
@@ -360,6 +379,7 @@ describe("GitHub Action", () => {
 			run: {
 				id: "test-id",
 				shortId: "short-id",
+				url: "https://app.qa.tech/dashboard/p/test-project/results/short-id",
 			},
 		};
 
@@ -392,6 +412,11 @@ describe("GitHub Action", () => {
 		expect(getRunStatus).toHaveBeenCalledTimes(3);
 		expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
 		expect(core.setOutput).toHaveBeenCalledWith("run_result", "PASSED");
+		expect(core.info).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Test run completed successfully. View results at:",
+			),
+		);
 
 		vi.useRealTimers();
 	});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,286 +2,350 @@ import * as core from "@actions/core";
 import type * as github from "@actions/github";
 // src/__tests__/index.test.ts
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { triggerQATechRun } from "../api-client";
+import { getRunStatus, triggerQATechRun } from "../api-client";
 import { run } from "../index";
 
 vi.mock("@actions/core");
-vi.mock("../api-client");
+vi.mock("../api-client", () => ({
+  triggerQATechRun: vi.fn(),
+  getRunStatus: vi.fn(),
+}));
 vi.mock("@actions/github", () => ({
-	default: vi.fn(),
-	context: {
-		actor: "testUser",
-		ref: "refs/heads/main",
-		sha: "abc123",
-		repo: {
-			owner: "test-owner",
-			repo: "test-repo",
-		},
-	} as typeof github.context,
+  default: vi.fn(),
+  context: {
+    actor: "testUser",
+    ref: "refs/heads/main",
+    sha: "abc123",
+    repo: {
+      owner: "test-owner",
+      repo: "test-repo",
+    },
+  } as typeof github.context,
 }));
 
 describe("GitHub Action", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
 
-		// Default core.getInput mock implementation
-		vi.mocked(core.getInput).mockImplementation((name) => {
-			switch (name) {
-				case "project_id":
-					return "test-project";
-				case "api_token":
-					return "test-token-12345";
-				case "api_url":
-					return "";
-				case "test_plan_short_ids":
-					return "";
-				default:
-					return "";
-			}
-		});
-	});
+    // Default core.getInput mock implementation
+    vi.mocked(core.getInput).mockImplementation((name) => {
+      switch (name) {
+        case "project_id":
+          return "test-project";
+        case "api_token":
+          return "test-token-12345";
+        case "api_url":
+          return "";
+        case "test_plan_short_ids":
+          return "";
+        default:
+          return "";
+      }
+    });
+  });
 
-	it("should successfully start a run and set run outputs", async () => {
-		const mockRunResponse = {
-			run: {
-				id: "test-id",
-				shortId: "short-id",
-			},
-		};
+  it("should successfully start a run and set run outputs", async () => {
+    const mockRunResponse = {
+      run: {
+        id: "test-id",
+        shortId: "short-id",
+      },
+    };
 
-		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-		await run();
+    await run();
 
-		expect(triggerQATechRun).toHaveBeenCalledWith(
-			"https://app.qa.tech/api/projects/test-project/runs",
-			"test-token-12345",
-			{
-				trigger: "GITHUB",
-				actor: "testUser",
-				branch: "refs/heads/main",
-				commitHash: "abc123",
-				repository: "test-repo",
-			},
-		);
-		expect(core.setOutput).toHaveBeenCalledWith("runId", "test-id");
-		expect(core.setOutput).toHaveBeenCalledWith("runShortId", "short-id");
-		expect(core.setFailed).not.toHaveBeenCalled();
-	});
+    expect(triggerQATechRun).toHaveBeenCalledWith(
+      "https://app.qa.tech/api/projects/test-project/runs",
+      "test-token-12345",
+      {
+        trigger: "GITHUB",
+        actor: "testUser",
+        branch: "refs/heads/main",
+        commitHash: "abc123",
+        repository: "test-repo",
+      }
+    );
+    expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
+    expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
 
-	it("should successfully start a run and set success output", async () => {
-		const mockRunResponse = {
-			success: true,
-		};
+  it("should handle failed run creation", async () => {
+    const mockRunResponse = {};
 
-		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-		await run();
+    await run();
 
-		expect(core.setOutput).toHaveBeenCalledWith("success", true);
-		expect(core.info).toHaveBeenCalledWith("QA.tech run success: true");
-		expect(core.setFailed).not.toHaveBeenCalled();
-	});
+    expect(core.setOutput).toHaveBeenCalledWith("run_created", "false");
+    expect(core.setFailed).toHaveBeenCalledWith(
+      "No run details returned from API"
+    );
+  });
 
-	it("should successfully start a run with test plans", async () => {
-		const testPlans = "plan1,plan2, plan3";
-		vi.mocked(core.getInput).mockImplementation((name) => {
-			switch (name) {
-				case "test_plan_short_ids":
-					return testPlans;
-				case "project_id":
-					return "test-project";
-				case "api_token":
-					return "test-token-12345";
-				default:
-					return "";
-			}
-		});
+  it("should successfully start a run with test plans", async () => {
+    const testPlans = "plan1,plan2, plan3";
+    vi.mocked(core.getInput).mockImplementation((name) => {
+      switch (name) {
+        case "test_plan_short_ids":
+          return testPlans;
+        case "project_id":
+          return "test-project";
+        case "api_token":
+          return "test-token-12345";
+        default:
+          return "";
+      }
+    });
 
-		const mockRunResponse = {
-			run: {
-				id: "test-id",
-				shortId: "short-id",
-			},
-		};
+    const mockRunResponse = {
+      run: {
+        id: "test-id",
+        shortId: "short-id",
+      },
+    };
 
-		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-		await run();
+    await run();
 
-		expect(triggerQATechRun).toHaveBeenCalledWith(
-			"https://app.qa.tech/api/projects/test-project/runs",
-			"test-token-12345",
-			expect.objectContaining({
-				testPlanShortIds: ["plan1", "plan2", "plan3"],
-			}),
-		);
-	});
+    expect(triggerQATechRun).toHaveBeenCalledWith(
+      "https://app.qa.tech/api/projects/test-project/runs",
+      "test-token-12345",
+      expect.objectContaining({
+        testPlanShortIds: ["plan1", "plan2", "plan3"],
+      })
+    );
+  });
 
-	it("should fail when API URL is invalid", async () => {
-		vi.mocked(core.getInput).mockImplementation((name) => {
-			switch (name) {
-				case "api_url":
-					return "invalid-url";
-				case "project_id":
-					return "test-project";
-				case "api_token":
-					return "test-token-12345";
-				default:
-					return "";
-			}
-		});
+  it("should fail when API URL is invalid", async () => {
+    vi.mocked(core.getInput).mockImplementation((name) => {
+      switch (name) {
+        case "api_url":
+          return "invalid-url";
+        case "project_id":
+          return "test-project";
+        case "api_token":
+          return "test-token-12345";
+        default:
+          return "";
+      }
+    });
 
-		await run();
+    await run();
 
-		expect(core.setFailed).toHaveBeenCalledWith("Invalid API URL: invalid-url");
-		expect(triggerQATechRun).not.toHaveBeenCalled();
-	});
+    expect(core.setFailed).toHaveBeenCalledWith("Invalid API URL: invalid-url");
+    expect(triggerQATechRun).not.toHaveBeenCalled();
+  });
 
-	it("should handle empty test plan IDs", async () => {
-		const mockRunResponse = {
-			run: {
-				id: "test-id",
-				shortId: "short-id",
-			},
-		};
+  it("should handle empty test plan IDs", async () => {
+    const mockRunResponse = {
+      run: {
+        id: "test-id",
+        shortId: "short-id",
+      },
+    };
 
-		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-		await run();
+    await run();
 
-		expect(triggerQATechRun).toHaveBeenCalledWith(
-			expect.any(String),
-			expect.any(String),
-			expect.not.objectContaining({
-				testPlanShortIds: expect.anything(),
-			}),
-		);
-	});
+    expect(triggerQATechRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.not.objectContaining({
+        testPlanShortIds: expect.anything(),
+      })
+    );
+  });
 
-	it("should handle malformed test plan IDs", async () => {
-		vi.mocked(core.getInput).mockImplementation((name) => {
-			switch (name) {
-				case "test_plan_short_ids":
-					return ",,test1,,test2,,";
-				case "project_id":
-					return "test-project";
-				case "api_token":
-					return "test-token-12345";
-				default:
-					return "";
-			}
-		});
+  it("should handle malformed test plan IDs", async () => {
+    vi.mocked(core.getInput).mockImplementation((name) => {
+      switch (name) {
+        case "test_plan_short_ids":
+          return ",,test1,,test2,,";
+        case "project_id":
+          return "test-project";
+        case "api_token":
+          return "test-token-12345";
+        default:
+          return "";
+      }
+    });
 
-		const mockRunResponse = {
-			run: {
-				id: "test-id",
-				shortId: "short-id",
-			},
-		};
+    const mockRunResponse = {
+      run: {
+        id: "test-id",
+        shortId: "short-id",
+      },
+    };
 
-		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-		await run();
+    await run();
 
-		expect(triggerQATechRun).toHaveBeenCalledWith(
-			expect.any(String),
-			expect.any(String),
-			expect.objectContaining({
-				testPlanShortIds: ["test1", "test2"],
-			}),
-		);
-	});
+    expect(triggerQATechRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        testPlanShortIds: ["test1", "test2"],
+      })
+    );
+  });
 
-	it("should handle HTTP 400 error", async () => {
-		const errorResponse = new Error("HTTP error! status: 400 - Bad Request");
-		vi.mocked(triggerQATechRun).mockRejectedValueOnce(errorResponse);
+  it("should handle HTTP 400 error", async () => {
+    const errorResponse = new Error("HTTP error! status: 400 - Bad Request");
+    vi.mocked(triggerQATechRun).mockRejectedValueOnce(errorResponse);
 
-		await run();
+    await run();
 
-		expect(core.setFailed).toHaveBeenCalledWith(
-			"Action failed: HTTP error! status: 400 - Bad Request",
-		);
-	});
+    expect(core.setFailed).toHaveBeenCalledWith(
+      "Action failed: HTTP error! status: 400 - Bad Request"
+    );
+  });
 
-	it("should fail when project_id is missing", async () => {
-		vi.mocked(core.getInput).mockImplementation((name, options) => {
-			if (name === "project_id" && options?.required) {
-				throw new Error("Input required and not supplied: project_id");
-			}
-			return name === "api_token" ? "test-token" : "";
-		});
+  it("should fail when project_id is missing", async () => {
+    vi.mocked(core.getInput).mockImplementation((name, options) => {
+      if (name === "project_id" && options?.required) {
+        throw new Error("Input required and not supplied: project_id");
+      }
+      return name === "api_token" ? "test-token" : "";
+    });
 
-		await run();
+    await run();
 
-		expect(core.setFailed).toHaveBeenCalledWith(
-			"Action failed: Input required and not supplied: project_id",
-		);
-		expect(triggerQATechRun).not.toHaveBeenCalled();
-	});
+    expect(core.setFailed).toHaveBeenCalledWith(
+      "Action failed: Input required and not supplied: project_id"
+    );
+    expect(triggerQATechRun).not.toHaveBeenCalled();
+  });
 
-	it("should fail when api_token is missing", async () => {
-		vi.mocked(core.getInput).mockImplementation((name, options) => {
-			if (name === "api_token" && options?.required) {
-				throw new Error("Input required and not supplied: api_token");
-			}
-			return name === "project_id" ? "test-project" : "";
-		});
+  it("should fail when api_token is missing", async () => {
+    vi.mocked(core.getInput).mockImplementation((name, options) => {
+      if (name === "api_token" && options?.required) {
+        throw new Error("Input required and not supplied: api_token");
+      }
+      return name === "project_id" ? "test-project" : "";
+    });
 
-		await run();
+    await run();
 
-		expect(core.setFailed).toHaveBeenCalledWith(
-			"Action failed: Input required and not supplied: api_token",
-		);
-		expect(triggerQATechRun).not.toHaveBeenCalled();
-	});
+    expect(core.setFailed).toHaveBeenCalledWith(
+      "Action failed: Input required and not supplied: api_token"
+    );
+    expect(triggerQATechRun).not.toHaveBeenCalled();
+  });
 
-	it("should handle API errors", async () => {
-		const error = new Error("API Error");
-		vi.mocked(triggerQATechRun).mockRejectedValueOnce(error);
+  it("should handle API errors", async () => {
+    const error = new Error("API Error");
+    vi.mocked(triggerQATechRun).mockRejectedValueOnce(error);
 
-		await run();
+    await run();
 
-		expect(core.setFailed).toHaveBeenCalledWith("Action failed: API Error");
-	});
+    expect(core.setFailed).toHaveBeenCalledWith("Action failed: API Error");
+  });
 
-	it("should handle unknown errors", async () => {
-		vi.mocked(triggerQATechRun).mockRejectedValueOnce("unknown error");
+  it("should handle unknown errors", async () => {
+    vi.mocked(triggerQATechRun).mockRejectedValueOnce("unknown error");
 
-		await run();
+    await run();
 
-		expect(core.setFailed).toHaveBeenCalledWith("An unexpected error occurred");
-	});
+    expect(core.setFailed).toHaveBeenCalledWith("An unexpected error occurred");
+  });
 
-	it("should use custom API URL when provided", async () => {
-		const customApiUrl = "https://custom.qa.tech";
-		vi.mocked(core.getInput).mockImplementation((name) => {
-			switch (name) {
-				case "api_url":
-					return customApiUrl;
-				case "project_id":
-					return "test-project";
-				case "api_token":
-					return "test-token-12345";
-				default:
-					return "";
-			}
-		});
+  it("should use custom API URL when provided", async () => {
+    const customApiUrl = "https://custom.qa.tech";
+    vi.mocked(core.getInput).mockImplementation((name) => {
+      switch (name) {
+        case "api_url":
+          return customApiUrl;
+        case "project_id":
+          return "test-project";
+        case "api_token":
+          return "test-token-12345";
+        default:
+          return "";
+      }
+    });
 
-		const mockRunResponse = {
-			run: {
-				id: "test-id",
-				shortId: "short-id",
-			},
-		};
-		vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    const mockRunResponse = {
+      run: {
+        id: "test-id",
+        shortId: "short-id",
+      },
+    };
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
 
-		await run();
+    await run();
 
-		expect(triggerQATechRun).toHaveBeenCalledWith(
-			`${customApiUrl}/api/projects/test-project/runs`,
-			"test-token-12345",
-			expect.any(Object),
-		);
-	});
+    expect(triggerQATechRun).toHaveBeenCalledWith(
+      `${customApiUrl}/api/projects/test-project/runs`,
+      "test-token-12345",
+      expect.any(Object)
+    );
+  });
+
+  it("should handle blocking mode with successful completion", async () => {
+    vi.mocked(core.getBooleanInput).mockImplementation((name) => {
+      return name === "blocking";
+    });
+
+    const mockRunResponse = {
+      run: {
+        id: "test-id",
+        shortId: "short-id",
+      },
+    };
+
+    const mockStatusResponse = {
+      id: "test-id",
+      short_id: "short-id",
+      status: "COMPLETED" as const,
+      result: "PASSED" as const,
+    };
+
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    vi.mocked(getRunStatus).mockResolvedValueOnce(mockStatusResponse);
+
+    await run();
+
+    expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
+    expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
+    expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
+    expect(core.setOutput).toHaveBeenCalledWith("run_result", "PASSED");
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  it("should handle blocking mode with failed completion", async () => {
+    vi.mocked(core.getBooleanInput).mockImplementation((name) => {
+      return name === "blocking";
+    });
+
+    const mockRunResponse = {
+      run: {
+        id: "test-id",
+        shortId: "short-id",
+      },
+    };
+
+    const mockStatusResponse = {
+      id: "test-id",
+      short_id: "short-id",
+      status: "COMPLETED" as const,
+      result: "FAILED" as const,
+    };
+
+    vi.mocked(triggerQATechRun).mockResolvedValueOnce(mockRunResponse);
+    vi.mocked(getRunStatus).mockResolvedValueOnce(mockStatusResponse);
+
+    await run();
+
+    expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
+    expect(core.setOutput).toHaveBeenCalledWith("run_short_id", "short-id");
+    expect(core.setOutput).toHaveBeenCalledWith("run_status", "COMPLETED");
+    expect(core.setOutput).toHaveBeenCalledWith("run_result", "FAILED");
+    expect(core.setFailed).toHaveBeenCalledWith("Test run failed");
+  });
 });

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -2,53 +2,93 @@ import * as core from "@actions/core";
 import fetch from "node-fetch";
 
 export interface RunDetails {
-	id: string;
-	shortId: string;
+  id: string;
+  shortId: string;
 }
 
 export interface Payload {
-	trigger: string;
-	actor: string;
-	branch: string;
-	commitHash: string;
-	repository: string;
-	testPlanShortIds?: string[];
+  trigger: string;
+  actor: string;
+  branch: string;
+  commitHash: string;
+  repository: string;
+  testPlanShortIds?: string[];
 }
 
 export interface ApiResponse {
-	success?: boolean;
-	run?: RunDetails;
+  success?: boolean;
+  run?: RunDetails;
+}
+
+export interface RunStatus {
+  id: string;
+  short_id: string;
+  status: "INITIATED" | "RUNNING" | "COMPLETED" | "ERROR" | "CANCELLED";
+  result: "PASSED" | "FAILED" | "SKIPPED" | null;
 }
 
 export const triggerQATechRun = async (
-	apiUrl: string,
-	apiToken: string,
-	payload: Payload,
+  apiUrl: string,
+  apiToken: string,
+  payload: Payload
 ): Promise<ApiResponse> => {
-	try {
-		const response = await fetch(apiUrl, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiToken}`,
-			},
-			body: JSON.stringify(payload),
-		});
+  try {
+    const response = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
 
-		if (!response.ok) {
-			throw new Error(
-				`HTTP error! status: ${response.status} - ${await response.text()}`,
-			);
-		}
+    if (!response.ok) {
+      throw new Error(
+        `HTTP error! status: ${response.status} - ${await response.text()}`
+      );
+    }
 
-		const apiResponse = (await response.json()) as ApiResponse;
-		return apiResponse;
-	} catch (error) {
-		if (error instanceof Error) {
-			core.error(`Error during fetch operation: ${error.message}`);
-		} else {
-			core.error("An unknown error occurred during fetch");
-		}
-		throw error;
-	}
+    const apiResponse = (await response.json()) as ApiResponse;
+    return apiResponse;
+  } catch (error) {
+    if (error instanceof Error) {
+      core.error(`Error during fetch operation: ${error.message}`);
+    } else {
+      core.error("An unknown error occurred during fetch");
+    }
+    throw error;
+  }
+};
+export const getRunStatus = async (
+  baseUrl: string,
+  projectId: string,
+  shortId: string,
+  apiToken: string
+): Promise<RunStatus> => {
+  try {
+    const response = await fetch(
+      `${baseUrl}/api/projects/${projectId}/runs/${shortId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `HTTP error! status: ${response.status} - ${await response.text()}`
+      );
+    }
+
+    const data = (await response.json()) as RunStatus;
+    return data;
+  } catch (error) {
+    if (error instanceof Error) {
+      core.error(`Error getting run status: ${error.message}`);
+    } else {
+      core.error("An unknown error occurred getting run status");
+    }
+    throw error;
+  }
 };

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -2,93 +2,93 @@ import * as core from "@actions/core";
 import fetch from "node-fetch";
 
 export interface RunDetails {
-  id: string;
-  shortId: string;
+	id: string;
+	shortId: string;
 }
 
 export interface Payload {
-  trigger: string;
-  actor: string;
-  branch: string;
-  commitHash: string;
-  repository: string;
-  testPlanShortIds?: string[];
+	trigger: string;
+	actor: string;
+	branch: string;
+	commitHash: string;
+	repository: string;
+	testPlanShortIds?: string[];
 }
 
 export interface ApiResponse {
-  success?: boolean;
-  run?: RunDetails;
+	success?: boolean;
+	run?: RunDetails;
 }
 
 export interface RunStatus {
-  id: string;
-  short_id: string;
-  status: "INITIATED" | "RUNNING" | "COMPLETED" | "ERROR" | "CANCELLED";
-  result: "PASSED" | "FAILED" | "SKIPPED" | null;
+	id: string;
+	short_id: string;
+	status: "INITIATED" | "RUNNING" | "COMPLETED" | "ERROR" | "CANCELLED";
+	result: "PASSED" | "FAILED" | "SKIPPED" | null;
 }
 
 export const triggerQATechRun = async (
-  apiUrl: string,
-  apiToken: string,
-  payload: Payload
+	apiUrl: string,
+	apiToken: string,
+	payload: Payload,
 ): Promise<ApiResponse> => {
-  try {
-    const response = await fetch(apiUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiToken}`,
-      },
-      body: JSON.stringify(payload),
-    });
+	try {
+		const response = await fetch(apiUrl, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${apiToken}`,
+			},
+			body: JSON.stringify(payload),
+		});
 
-    if (!response.ok) {
-      throw new Error(
-        `HTTP error! status: ${response.status} - ${await response.text()}`
-      );
-    }
+		if (!response.ok) {
+			throw new Error(
+				`HTTP error! status: ${response.status} - ${await response.text()}`,
+			);
+		}
 
-    const apiResponse = (await response.json()) as ApiResponse;
-    return apiResponse;
-  } catch (error) {
-    if (error instanceof Error) {
-      core.error(`Error during fetch operation: ${error.message}`);
-    } else {
-      core.error("An unknown error occurred during fetch");
-    }
-    throw error;
-  }
+		const apiResponse = (await response.json()) as ApiResponse;
+		return apiResponse;
+	} catch (error) {
+		if (error instanceof Error) {
+			core.error(`Error during fetch operation: ${error.message}`);
+		} else {
+			core.error("An unknown error occurred during fetch");
+		}
+		throw error;
+	}
 };
 export const getRunStatus = async (
-  baseUrl: string,
-  projectId: string,
-  shortId: string,
-  apiToken: string
+	baseUrl: string,
+	projectId: string,
+	shortId: string,
+	apiToken: string,
 ): Promise<RunStatus> => {
-  try {
-    const response = await fetch(
-      `${baseUrl}/api/projects/${projectId}/runs/${shortId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${apiToken}`,
-        },
-      }
-    );
+	try {
+		const response = await fetch(
+			`${baseUrl}/api/projects/${projectId}/runs/${shortId}`,
+			{
+				headers: {
+					Authorization: `Bearer ${apiToken}`,
+				},
+			},
+		);
 
-    if (!response.ok) {
-      throw new Error(
-        `HTTP error! status: ${response.status} - ${await response.text()}`
-      );
-    }
+		if (!response.ok) {
+			throw new Error(
+				`HTTP error! status: ${response.status} - ${await response.text()}`,
+			);
+		}
 
-    const data = (await response.json()) as RunStatus;
-    return data;
-  } catch (error) {
-    if (error instanceof Error) {
-      core.error(`Error getting run status: ${error.message}`);
-    } else {
-      core.error("An unknown error occurred getting run status");
-    }
-    throw error;
-  }
+		const data = (await response.json()) as RunStatus;
+		return data;
+	} catch (error) {
+		if (error instanceof Error) {
+			core.error(`Error getting run status: ${error.message}`);
+		} else {
+			core.error("An unknown error occurred getting run status");
+		}
+		throw error;
+	}
 };

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -4,6 +4,7 @@ import fetch from "node-fetch";
 export interface RunDetails {
 	id: string;
 	shortId: string;
+	url: string;
 }
 
 export interface Payload {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ export async function run(): Promise<void> {
 		const overrideApiUrl = core.getInput("api_url");
 		const baseApiUrl = overrideApiUrl.length === 0 ? BASE_URL : overrideApiUrl;
 		const blocking = core.getBooleanInput("blocking");
-
 		if (!validateUrl(baseApiUrl)) {
 			core.setFailed(`Invalid API URL: ${baseApiUrl}`);
 			return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,8 @@ export async function run(): Promise<void> {
 		const result = await triggerQATechRun(apiUrl, apiToken, payload);
 
 		if (result.run) {
-			core.setOutput("runId", result.run.id);
-			core.setOutput("runShortId", result.run.shortId);
+			core.setOutput("run_created", "true");
+			core.setOutput("run_short_id", result.run.shortId);
 			core.info(
 				`QA.tech run started with ID: ${result.run.id}, Short ID: ${result.run.shortId}`,
 			);
@@ -99,6 +99,9 @@ export async function run(): Promise<void> {
 					);
 
 					if (status.status === "COMPLETED") {
+						core.setOutput("run_status", status.status);
+						core.setOutput("run_result", status.result);
+
 						if (status.result === "FAILED") {
 							core.setFailed("Test run failed");
 							return;
@@ -113,13 +116,9 @@ export async function run(): Promise<void> {
 						}
 					}
 
-					if (status.status === "ERROR") {
-						core.setFailed("Test run encountered an error");
-						return;
-					}
-
-					if (status.status === "CANCELLED") {
-						core.setFailed("Test run was cancelled");
+					if (status.status === "ERROR" || status.status === "CANCELLED") {
+						core.setOutput("run_status", status.status);
+						core.setFailed(`Test run ${status.status.toLowerCase()}`);
 						return;
 					}
 
@@ -128,6 +127,7 @@ export async function run(): Promise<void> {
 				}
 			}
 		} else {
+			core.setOutput("run_created", "false");
 			core.setFailed("No run details returned from API");
 			return;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,95 +1,144 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import { type Payload, triggerQATechRun } from "./api-client";
+import { getRunStatus, type Payload, triggerQATechRun } from "./api-client";
 
 const BASE_URL = "https://app.qa.tech";
+const POLLING_INTERVAL = 20000; // 20 seconds in milliseconds
 
 const validateUrl = (url: string): boolean => {
-	try {
-		new URL(url);
-		return true;
-	} catch {
-		return false;
-	}
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
 };
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 const parseTestPlanShortIds = (input: string): string[] => {
-	if (!input) return [];
-	return input
-		.split(",")
-		.map((id) => id.trim())
-		.filter(Boolean);
+  if (!input) return [];
+  return input
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
 };
 
 const getStartRunUrl = (baseUrl: string, projectId: string) =>
-	`${baseUrl}/api/projects/${projectId}/runs`;
+  `${baseUrl}/api/projects/${projectId}/runs`;
 
 export async function run(): Promise<void> {
-	try {
-		core.debug("Starting the action");
-		const overrideApiUrl = core.getInput("api_url");
-		const baseApiUrl = overrideApiUrl.length === 0 ? BASE_URL : overrideApiUrl;
+  try {
+    core.debug("Starting the action");
+    const overrideApiUrl = core.getInput("api_url");
+    const baseApiUrl = overrideApiUrl.length === 0 ? BASE_URL : overrideApiUrl;
+    const blocking = core.getBooleanInput("blocking");
 
-		if (!validateUrl(baseApiUrl)) {
-			core.setFailed(`Invalid API URL: ${baseApiUrl}`);
-			return;
-		}
+    if (!validateUrl(baseApiUrl)) {
+      core.setFailed(`Invalid API URL: ${baseApiUrl}`);
+      return;
+    }
 
-		const projectId = core.getInput("project_id", { required: true });
-		const apiToken = core.getInput("api_token", { required: true });
-		const testPlanShortIds = parseTestPlanShortIds(
-			core.getInput("test_plan_short_ids"),
-		);
+    const projectId = core.getInput("project_id", { required: true });
+    const apiToken = core.getInput("api_token", { required: true });
+    const testPlanShortIds = parseTestPlanShortIds(
+      core.getInput("test_plan_short_ids")
+    );
 
-		if (!projectId) {
-			core.setFailed('The "project_id" input is required');
-			return;
-		}
+    if (!projectId) {
+      core.setFailed('The "project_id" input is required');
+      return;
+    }
 
-		if (!apiToken) {
-			core.setFailed('The "api_token" input is required');
-			return;
-		}
+    if (!apiToken) {
+      core.setFailed('The "api_token" input is required');
+      return;
+    }
 
-		const apiUrl = getStartRunUrl(baseApiUrl, projectId);
-		const { actor, ref, sha, repo } = github.context;
+    const apiUrl = getStartRunUrl(baseApiUrl, projectId);
+    const { actor, ref, sha, repo } = github.context;
 
-		const payload: Payload = {
-			trigger: "GITHUB",
-			actor,
-			branch: ref,
-			commitHash: sha,
-			repository: repo.repo,
-		};
+    const payload: Payload = {
+      trigger: "GITHUB",
+      actor,
+      branch: ref,
+      commitHash: sha,
+      repository: repo.repo,
+    };
 
-		if (testPlanShortIds.length > 0) {
-			core.debug(`Including test plans: ${testPlanShortIds.join(", ")}`);
-			payload.testPlanShortIds = testPlanShortIds;
-		}
+    if (testPlanShortIds.length > 0) {
+      core.debug(`Including test plans: ${testPlanShortIds.join(", ")}`);
+      payload.testPlanShortIds = testPlanShortIds;
+    }
 
-		core.debug(
-			`Triggering QA.tech run with payload: ${JSON.stringify(payload)}`,
-		);
+    core.debug(
+      `Triggering QA.tech run with payload: ${JSON.stringify(payload)}`
+    );
 
-		const result = await triggerQATechRun(apiUrl, apiToken, payload);
+    const result = await triggerQATechRun(apiUrl, apiToken, payload);
 
-		if (result.success !== undefined) {
-			core.setOutput("success", result.success);
-			core.info(`QA.tech run success: ${result.success}`);
-		} else if (result.run) {
-			core.setOutput("runId", result.run.id);
-			core.setOutput("runShortId", result.run.shortId);
-			core.info(
-				`QA.tech run started with ID: ${result.run.id}, Short ID: ${result.run.shortId}`,
-			);
-		}
-	} catch (error) {
-		if (error instanceof Error) {
-			core.setFailed(`Action failed: ${error.message}`);
-		} else {
-			core.setFailed("An unexpected error occurred");
-		}
-	}
+    if (result.run) {
+      core.setOutput("runId", result.run.id);
+      core.setOutput("runShortId", result.run.shortId);
+      core.info(
+        `QA.tech run started with ID: ${result.run.id}, Short ID: ${result.run.shortId}`
+      );
+
+      if (blocking) {
+        core.info("Waiting for test results...");
+        while (true) {
+          const status = await getRunStatus(
+            baseApiUrl,
+            projectId,
+            result.run.shortId,
+            apiToken
+          );
+          core.info(
+            `Current status: ${status.status}, Result: ${
+              status.result || "pending"
+            }`
+          );
+
+          if (status.status === "COMPLETED") {
+            if (status.result === "FAILED") {
+              core.setFailed("Test run failed");
+              return;
+            }
+            if (status.result === "PASSED") {
+              core.info("Test run completed successfully");
+              return;
+            }
+            if (status.result === "SKIPPED") {
+              core.warning("Test run was skipped");
+              return;
+            }
+          }
+
+          if (status.status === "ERROR") {
+            core.setFailed("Test run encountered an error");
+            return;
+          }
+
+          if (status.status === "CANCELLED") {
+            core.setFailed("Test run was cancelled");
+            return;
+          }
+
+          // If still running or initiated, wait and check again
+          await sleep(POLLING_INTERVAL);
+        }
+      }
+    } else {
+      core.setFailed("No run details returned from API");
+      return;
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      core.setFailed(`Action failed: ${error.message}`);
+    } else {
+      core.setFailed("An unexpected error occurred");
+    }
+  }
 }
 
 run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export async function run(): Promise<void> {
 
 					if (status.status === "ERROR" || status.status === "CANCELLED") {
 						core.setOutput("run_status", status.status);
-						core.setFailed(`Test run ${status.status.toLowerCase()}`);
+						core.setFailed(`Run ${status.status.toLowerCase()}`);
 						return;
 					}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,144 +1,144 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import { getRunStatus, type Payload, triggerQATechRun } from "./api-client";
+import { type Payload, getRunStatus, triggerQATechRun } from "./api-client";
 
 const BASE_URL = "https://app.qa.tech";
 const POLLING_INTERVAL = 20000; // 20 seconds in milliseconds
 
 const validateUrl = (url: string): boolean => {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		new URL(url);
+		return true;
+	} catch {
+		return false;
+	}
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const parseTestPlanShortIds = (input: string): string[] => {
-  if (!input) return [];
-  return input
-    .split(",")
-    .map((id) => id.trim())
-    .filter(Boolean);
+	if (!input) return [];
+	return input
+		.split(",")
+		.map((id) => id.trim())
+		.filter(Boolean);
 };
 
 const getStartRunUrl = (baseUrl: string, projectId: string) =>
-  `${baseUrl}/api/projects/${projectId}/runs`;
+	`${baseUrl}/api/projects/${projectId}/runs`;
 
 export async function run(): Promise<void> {
-  try {
-    core.debug("Starting the action");
-    const overrideApiUrl = core.getInput("api_url");
-    const baseApiUrl = overrideApiUrl.length === 0 ? BASE_URL : overrideApiUrl;
-    const blocking = core.getBooleanInput("blocking");
+	try {
+		core.debug("Starting the action");
+		const overrideApiUrl = core.getInput("api_url");
+		const baseApiUrl = overrideApiUrl.length === 0 ? BASE_URL : overrideApiUrl;
+		const blocking = core.getBooleanInput("blocking");
 
-    if (!validateUrl(baseApiUrl)) {
-      core.setFailed(`Invalid API URL: ${baseApiUrl}`);
-      return;
-    }
+		if (!validateUrl(baseApiUrl)) {
+			core.setFailed(`Invalid API URL: ${baseApiUrl}`);
+			return;
+		}
 
-    const projectId = core.getInput("project_id", { required: true });
-    const apiToken = core.getInput("api_token", { required: true });
-    const testPlanShortIds = parseTestPlanShortIds(
-      core.getInput("test_plan_short_ids")
-    );
+		const projectId = core.getInput("project_id", { required: true });
+		const apiToken = core.getInput("api_token", { required: true });
+		const testPlanShortIds = parseTestPlanShortIds(
+			core.getInput("test_plan_short_ids"),
+		);
 
-    if (!projectId) {
-      core.setFailed('The "project_id" input is required');
-      return;
-    }
+		if (!projectId) {
+			core.setFailed('The "project_id" input is required');
+			return;
+		}
 
-    if (!apiToken) {
-      core.setFailed('The "api_token" input is required');
-      return;
-    }
+		if (!apiToken) {
+			core.setFailed('The "api_token" input is required');
+			return;
+		}
 
-    const apiUrl = getStartRunUrl(baseApiUrl, projectId);
-    const { actor, ref, sha, repo } = github.context;
+		const apiUrl = getStartRunUrl(baseApiUrl, projectId);
+		const { actor, ref, sha, repo } = github.context;
 
-    const payload: Payload = {
-      trigger: "GITHUB",
-      actor,
-      branch: ref,
-      commitHash: sha,
-      repository: repo.repo,
-    };
+		const payload: Payload = {
+			trigger: "GITHUB",
+			actor,
+			branch: ref,
+			commitHash: sha,
+			repository: repo.repo,
+		};
 
-    if (testPlanShortIds.length > 0) {
-      core.debug(`Including test plans: ${testPlanShortIds.join(", ")}`);
-      payload.testPlanShortIds = testPlanShortIds;
-    }
+		if (testPlanShortIds.length > 0) {
+			core.debug(`Including test plans: ${testPlanShortIds.join(", ")}`);
+			payload.testPlanShortIds = testPlanShortIds;
+		}
 
-    core.debug(
-      `Triggering QA.tech run with payload: ${JSON.stringify(payload)}`
-    );
+		core.debug(
+			`Triggering QA.tech run with payload: ${JSON.stringify(payload)}`,
+		);
 
-    const result = await triggerQATechRun(apiUrl, apiToken, payload);
+		const result = await triggerQATechRun(apiUrl, apiToken, payload);
 
-    if (result.run) {
-      core.setOutput("runId", result.run.id);
-      core.setOutput("runShortId", result.run.shortId);
-      core.info(
-        `QA.tech run started with ID: ${result.run.id}, Short ID: ${result.run.shortId}`
-      );
+		if (result.run) {
+			core.setOutput("runId", result.run.id);
+			core.setOutput("runShortId", result.run.shortId);
+			core.info(
+				`QA.tech run started with ID: ${result.run.id}, Short ID: ${result.run.shortId}`,
+			);
 
-      if (blocking) {
-        core.info("Waiting for test results...");
-        while (true) {
-          const status = await getRunStatus(
-            baseApiUrl,
-            projectId,
-            result.run.shortId,
-            apiToken
-          );
-          core.info(
-            `Current status: ${status.status}, Result: ${
-              status.result || "pending"
-            }`
-          );
+			if (blocking) {
+				core.info("Waiting for test results...");
+				while (true) {
+					const status = await getRunStatus(
+						baseApiUrl,
+						projectId,
+						result.run.shortId,
+						apiToken,
+					);
+					core.info(
+						`Current status: ${status.status}, Result: ${
+							status.result || "pending"
+						}`,
+					);
 
-          if (status.status === "COMPLETED") {
-            if (status.result === "FAILED") {
-              core.setFailed("Test run failed");
-              return;
-            }
-            if (status.result === "PASSED") {
-              core.info("Test run completed successfully");
-              return;
-            }
-            if (status.result === "SKIPPED") {
-              core.warning("Test run was skipped");
-              return;
-            }
-          }
+					if (status.status === "COMPLETED") {
+						if (status.result === "FAILED") {
+							core.setFailed("Test run failed");
+							return;
+						}
+						if (status.result === "PASSED") {
+							core.info("Test run completed successfully");
+							return;
+						}
+						if (status.result === "SKIPPED") {
+							core.warning("Test run was skipped");
+							return;
+						}
+					}
 
-          if (status.status === "ERROR") {
-            core.setFailed("Test run encountered an error");
-            return;
-          }
+					if (status.status === "ERROR") {
+						core.setFailed("Test run encountered an error");
+						return;
+					}
 
-          if (status.status === "CANCELLED") {
-            core.setFailed("Test run was cancelled");
-            return;
-          }
+					if (status.status === "CANCELLED") {
+						core.setFailed("Test run was cancelled");
+						return;
+					}
 
-          // If still running or initiated, wait and check again
-          await sleep(POLLING_INTERVAL);
-        }
-      }
-    } else {
-      core.setFailed("No run details returned from API");
-      return;
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      core.setFailed(`Action failed: ${error.message}`);
-    } else {
-      core.setFailed("An unexpected error occurred");
-    }
-  }
+					// If still running or initiated, wait and check again
+					await sleep(POLLING_INTERVAL);
+				}
+			}
+		} else {
+			core.setFailed("No run details returned from API");
+			return;
+		}
+	} catch (error) {
+		if (error instanceof Error) {
+			core.setFailed(`Action failed: ${error.message}`);
+		} else {
+			core.setFailed("An unexpected error occurred");
+		}
+	}
 }
 
 run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,10 @@ export async function run(): Promise<void> {
 			core.info(
 				`QA.tech run started with ID: ${result.run.id}, Short ID: ${result.run.shortId}`,
 			);
+			core.info(`View run at: ${result.run.url}`);
 
 			if (blocking) {
-				core.info("Waiting for test results...");
+				core.info(`Waiting for test results... (${result.run.url})`);
 				while (true) {
 					const status = await getRunStatus(
 						baseApiUrl,
@@ -103,22 +104,32 @@ export async function run(): Promise<void> {
 						core.setOutput("run_result", status.result);
 
 						if (status.result === "FAILED") {
-							core.setFailed("Test run failed");
+							core.setFailed(
+								`Test run failed. View results at: ${result.run.url}`,
+							);
 							return;
 						}
 						if (status.result === "PASSED") {
-							core.info("Test run completed successfully");
+							core.info(
+								`Test run completed successfully. View results at: ${result.run.url}`,
+							);
 							return;
 						}
 						if (status.result === "SKIPPED") {
-							core.warning("Test run was skipped");
+							core.warning(
+								`Test run was skipped. View details at: ${result.run.url}`,
+							);
 							return;
 						}
 					}
 
 					if (status.status === "ERROR" || status.status === "CANCELLED") {
 						core.setOutput("run_status", status.status);
-						core.setFailed(`Run ${status.status.toLowerCase()}`);
+						core.setFailed(
+							`Run ${status.status.toLowerCase()}. View details at: ${
+								result.run.url
+							}`,
+						);
 						return;
 					}
 


### PR DESCRIPTION
This pull request includes several changes to add blocking functionality to the QA tech run process and enhance the API client. The most important changes include adding a new `blocking` input parameter, introducing a new `RunStatus` interface, and implementing a polling mechanism to check the run status.
