### PR TITLE
feat!: change test_plan_short_ids to singular test_plan_short_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ jobs:
         with:
           project_id: 'your-project-id'
           api_token: ${{ secrets.QATECH_API_TOKEN }}
-          blocking: true
-          test_plan_short_ids: 'jgbinp,j1kn1,ocjmd' # Optional, comma-separated list of test plan short IDs
+          test_plan_short_id: 'jgbinp' # Optional, test plan short ID
 ```
 
 ## Inputs
@@ -30,8 +29,7 @@ jobs:
 | `project_id` | Your QA.tech project ID | Yes | - |
 | `api_token` | QA.tech API token | Yes | - |
 | `api_url` | Custom API URL if needed | No | <https://app.qa.tech> |
-| `test_plan_short_ids` | Comma-separated list of test plan IDs to run | No | - |
-| `blocking` | Wait for test results before completing the workflow | No | false |
+| `test_plan_short_id` | Test plan ID to run | No | - |
 
 You can find your project ID and generate an API token in your [QA.tech project settings](https://app.qa.tech/dashboard/current-project/settings/integrations).
 
@@ -39,29 +37,22 @@ You can find your project ID and generate an API token in your [QA.tech project 
 
 | Output | Description |
 |--------|-------------|
-| `run_created` | Whether the test run was created successfully on QA.tech |
-| `run_short_id` | The short ID of the run. |
-| `run_result` | The test execution result. Only set when blocking is true. |
-| `run_status` | The final status of the run. Only set when blocking is true. |
+| `runId` | The ID of the created test run |
+| `runShortId` | A short ID for the test run |
+| `success` | Boolean indicating if the run was successful |
 
-### Blocking mode
+## Test Plan
 
-When `blocking`is set to `true, the action will:
+Specify which test plan to run by providing its ID in the test_plan_short_id input. To run multiple test plans, simply use the GitHub Action multiple times in your workflow.
 
-- Wait for all tests to complete execution
-- Report the final test results before proceeding
-- Fail the workflow step if any tests fail
-
-### Test Plans
-
-You can specify which test plans to run by providing their IDs in the `test_plan_short_ids` input. Multiple test plans should be separated by commas. For example:
+For example:
 
 ```yaml
 - uses: QAdottech/run-action@v1
   with:
     project_id: 'your-project-id'
     api_token: ${{ secrets.QATECH_API_TOKEN }}
-    test_plan_short_ids: 'jgbinp,j1kn1,ocjmd'
+    test_plan_short_id: 'jgbinp'
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
 | `project_id` | Your QA.tech project ID | Yes | - |
 | `api_token` | QA.tech API token | Yes | - |
 | `api_url` | Custom API URL if needed | No | <https://app.qa.tech> |
-| `test_plan_short_id` | Test plan ID to run | No | - |
+| `test_plan_short_id` | Test plan short ID to run | No | - |
 
 You can find your project ID and generate an API token in your [QA.tech project settings](https://app.qa.tech/dashboard/current-project/settings/integrations).
 

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
   api_url:
     description: 'The API url for QA.techs API. Defaults to production.'
     required: false
-  test_plan_short_ids:
-    description: 'The test plan IDs to run the tests in.'
+  test_plan_short_id:
+    description: 'The unique identifier (test plan short ID) for a single test plan to execute.'
     required: false
   blocking:
     description: 'Whether the run should be blocking.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -39352,13 +39352,10 @@ const validateUrl = (url) => {
     }
 };
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-const parseTestPlanShortIds = (input) => {
+const parseTestPlanShortId = (input) => {
     if (!input)
-        return [];
-    return input
-        .split(",")
-        .map((id) => id.trim())
-        .filter(Boolean);
+        return "";
+    return input.trim();
 };
 const getStartRunUrl = (baseUrl, projectId) => `${baseUrl}/api/projects/${projectId}/runs`;
 async function run() {
@@ -39373,7 +39370,7 @@ async function run() {
         }
         const projectId = core.getInput("project_id", { required: true });
         const apiToken = core.getInput("api_token", { required: true });
-        const testPlanShortIds = parseTestPlanShortIds(core.getInput("test_plan_short_ids"));
+        const testPlanShortId = parseTestPlanShortId(core.getInput("test_plan_short_id"));
         if (!projectId) {
             core.setFailed('The "project_id" input is required');
             return;
@@ -39391,9 +39388,9 @@ async function run() {
             commitHash: sha,
             repository: repo.repo,
         };
-        if (testPlanShortIds.length > 0) {
-            core.debug(`Including test plans: ${testPlanShortIds.join(", ")}`);
-            payload.testPlanShortIds = testPlanShortIds;
+        if (testPlanShortId) {
+            core.debug(`Including test plan: ${testPlanShortId}`);
+            payload.testPlanShortId = testPlanShortId;
         }
         core.debug(`Triggering QA.tech run with payload: ${JSON.stringify(payload)}`);
         const result = await triggerQATechRun(apiUrl, apiToken, payload);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"keywords": ["QA", "actions", "QA.tech"],
 	"author": "QA Tech AB",
 	"license": "MIT",
-	"packageManager": "pnpm@9.15.0",
+	"packageManager": "pnpm@9.15.5",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@types/node": "^22.10.7",

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -13,7 +13,7 @@ export interface Payload {
 	branch: string;
 	commitHash: string;
 	repository: string;
-	testPlanShortIds?: string[];
+	testPlanShortId?: string;
 }
 
 export interface ApiResponse {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,9 @@ const validateUrl = (url: string): boolean => {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const parseTestPlanShortIds = (input: string): string[] => {
-	if (!input) return [];
-	return input
-		.split(",")
-		.map((id) => id.trim())
-		.filter(Boolean);
+const parseTestPlanShortId = (input: string): string => {
+	if (!input) return "";
+	return input.trim();
 };
 
 const getStartRunUrl = (baseUrl: string, projectId: string) =>
@@ -40,8 +37,8 @@ export async function run(): Promise<void> {
 
 		const projectId = core.getInput("project_id", { required: true });
 		const apiToken = core.getInput("api_token", { required: true });
-		const testPlanShortIds = parseTestPlanShortIds(
-			core.getInput("test_plan_short_ids"),
+		const testPlanShortId = parseTestPlanShortId(
+			core.getInput("test_plan_short_id"),
 		);
 
 		if (!projectId) {
@@ -65,9 +62,9 @@ export async function run(): Promise<void> {
 			repository: repo.repo,
 		};
 
-		if (testPlanShortIds.length > 0) {
-			core.debug(`Including test plans: ${testPlanShortIds.join(", ")}`);
-			payload.testPlanShortIds = testPlanShortIds;
+		if (testPlanShortId) {
+			core.debug(`Including test plan: ${testPlanShortId}`);
+			payload.testPlanShortId = testPlanShortId;
 		}
 
 		core.debug(


### PR DESCRIPTION
BREAKING CHANGE: Renamed `test_plan_short_ids` to `test_plan_short_id` and changed functionality to accept only a single test plan ID.

- Changed input parameter from `test_plan_short_ids` to `test_plan_short_id`
- Removed support for comma-separated test plan IDs
- Updated documentation to reflect new usage
- Added tests for new single ID behavior
- Updated API payload to use single ID

To run multiple test plans, users should now use multiple action steps in their workflow.

Example migration from v1 to v2:

```yaml
# v1
- uses: QAdottech/run-action@v1
  with:
    test_plan_short_ids: 'plan1,plan2,plan3'

# v2
- uses: QAdottech/run-action@v2
  with:
    test_plan_short_id: 'plan1'
- uses: QAdottech/run-action@v2
  with:
    test_plan_short_id: 'plan2'
- uses: QAdottech/run-action@v2
  with:
    test_plan_short_id: 'plan3'