### PR TITLE
Include owner in repository string

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "tabWidth": 2,
+  "useTabs": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "semi": true,
+  "singleAttributePerLine": false
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -39386,7 +39386,7 @@ async function run() {
             actor,
             branch: ref,
             commitHash: sha,
-            repository: repo.repo,
+            repository: `${repo.owner}/${repo.repo}`,
         };
         if (testPlanShortId) {
             core.debug(`Including test plan: ${testPlanShortId}`);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -67,7 +67,7 @@ describe("GitHub Action", () => {
 				actor: "testUser",
 				branch: "refs/heads/main",
 				commitHash: "abc123",
-				repository: "test-repo",
+				repository: "test-owner/test-repo",
 			},
 		);
 		expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -17,7 +17,7 @@ export interface Payload {
 	actor: string;
 	branch: string;
 	commitHash: string;
-	repository: string;
+	repository: `${string}/${string}`;
 	testPlanShortId?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export async function run(): Promise<void> {
 			actor,
 			branch: ref,
 			commitHash: sha,
-			repository: repo.repo,
+			repository: `${repo.owner}/${repo.repo}`,
 		};
 
 		if (testPlanShortId) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
 		"noEmit": true,
 		"allowJs": false
 	},
-	"include": ["src/**/*"],
+	"include": ["src/**/*", "src/__tests__/**/*"],
 	"exclude": ["dist/**/*", "node_modules"]
 }


### PR DESCRIPTION
I think this might have got lost in the rewrite? In the API route we expect it to include owner:
https://github.com/QAdottech/qatech/blob/4e44b8346af1fa61f5383b6e33055b4ea158b0d7/packages/database-types/index.ts#L34

Currently, links to the commit are broken.