### PR TITLE
Support for applications config for application environment overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
 | `api_url` | Custom API URL if needed | No | <https://app.qa.tech> |
 | `test_plan_short_id` | Test plan short ID to run | No | - |
 | `blocking` | Enables blocking mode to wait for the test run to complete | No | false |
-| `applications` | JSON string containing application environment overrides | No | - |
+| `applications_config` | JSON string containing application environment overrides | No | - |
 
 You can find your project ID and generate an API token in your [QA.tech project settings](https://app.qa.tech/dashboard/current-project/settings/integrations).
 
@@ -83,7 +83,7 @@ When blocking is enabled, the action provides additional outputs:
 
 ## Application Environment Overrides
 
-You can override application environments for specific runs using the `applications` input. This is useful for testing against preview deployments or specific environment URLs.
+You can override application environments for specific runs using the `applications_config` input. This is useful for testing against preview deployments or specific environment URLs.
 
 The input expects a JSON string with the following format:
 
@@ -108,7 +108,7 @@ The input expects a JSON string with the following format:
     project_id: 'your-project-id'
     api_token: ${{ secrets.QATECH_API_TOKEN }}
     test_plan_short_id: 'jgbinp'
-    applications: |
+    applications_config: |
       {
         "applications": {
           "short-id-1": {
@@ -122,10 +122,10 @@ The input expects a JSON string with the following format:
 
 You can override multiple applications in a single run:
 
-> **Note**: Check your QA.tech UI under Test Plans → API Integration to see which applications are connected to your test plan.
+> **Note**: Check on app.qa.tech under Test Plans → API Integration to see which applications are connected to your test plan.
 
 ```yaml
-applications: |
+applications_config: |
   {
     "applications": {
       "short-id-2": {

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ jobs:
 | `api_url` | Custom API URL if needed | No | <https://app.qa.tech> |
 | `test_plan_short_id` | Test plan short ID to run | No | - |
 | `blocking` | Enables blocking mode to wait for the test run to complete | No | false |
+| `applications` | JSON string containing application environment overrides | No | - |
 
 You can find your project ID and generate an API token in your [QA.tech project settings](https://app.qa.tech/dashboard/current-project/settings/integrations).
 
@@ -79,6 +80,69 @@ When blocking is enabled, the action provides additional outputs:
 
 - `run_status`: The final status of the run (INITIATED, RUNNING, COMPLETED, ERROR, or CANCELLED)
 - `run_result`: The test execution result (PASSED, FAILED, or SKIPPED)
+
+## Application Environment Overrides
+
+You can override application environments for specific runs using the `applications` input. This is useful for testing against preview deployments or specific environment URLs.
+
+The input expects a JSON string with the following format:
+
+```json
+{
+  "applications": {
+    "appId": {
+      "environment": {
+        "url": "https://preview-123.vercel.app",
+        "name": "Preview Environment"
+      }
+    }
+  }
+}
+```
+
+### Example Usage
+
+```yaml
+- uses: QAdottech/run-action@v2
+  with:
+    project_id: 'your-project-id'
+    api_token: ${{ secrets.QATECH_API_TOKEN }}
+    test_plan_short_id: 'jgbinp'
+    applications: |
+      {
+        "applications": {
+          "short-id-1": {
+            "environment": {
+              "url": "https://preview-123-hackoffice.vercel.app"
+            }
+          }
+        }
+      }
+```
+
+You can override multiple applications in a single run:
+
+> **Note**: Check your QA.tech UI under Test Plans → API Integration to see which applications are connected to your test plan.
+
+```yaml
+applications: |
+  {
+    "applications": {
+      "short-id-2": {
+        "environment": {
+          "url": "https://preview-123-hackoffice.vercel.app",
+          "name": "PR-123"
+        }
+      },
+      "short-id-2": {
+        "environment": {
+          "url": "https://preview-123-saas.vercel.app",
+          "name": "PR-123"
+        }
+      }
+    }
+  }
+```
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'Whether the run should be blocking.'
     required: false
     default: 'false'
+  applications:
+    description: 'JSON string containing application environment overrides. Format: {"applications": {"appId": {"environment": {"url": "...", "name": "..."}}}}'
+    required: false
 
 outputs:
   run_created:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Whether the run should be blocking.'
     required: false
     default: 'false'
-  applications:
+  applications_config:
     description: 'JSON string containing application environment overrides. Format: {"applications": {"appId": {"environment": {"url": "...", "name": "..."}}}}'
     required: false
 

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -24,7 +24,7 @@ export interface Payload {
 		{
 			environment: {
 				url: string;
-				name: string;
+				name?: string;
 			};
 		}
 	>;

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -19,6 +19,15 @@ export interface Payload {
 	commitHash: string;
 	repository: `${string}/${string}`;
 	testPlanShortId?: string;
+	applications?: Record<
+		string,
+		{
+			environment: {
+				url: string;
+				name: string;
+			};
+		}
+	>;
 }
 
 export interface ApiResponse {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,9 @@ export async function run(): Promise<void> {
 			core.getInput("test_plan_short_id"),
 		);
 
-		const applicationsInput = core.getInput("applications");
+		const applicationsInput = core.getInput("applications_config");
 		let applications:
-			| Record<string, { environment: { url: string; name: string } }>
+			| Record<string, { environment: { url: string; name?: string } }>
 			| undefined;
 
 		if (applicationsInput) {
@@ -55,13 +55,13 @@ export async function run(): Promise<void> {
 					core.debug(`Parsed applications: ${JSON.stringify(applications)}`);
 				} else {
 					core.setFailed(
-						'Applications input must contain an "applications" property at the root level',
+						'Applications config input must contain an "applications" property at the root level',
 					);
 					return;
 				}
 			} catch (error) {
 				core.setFailed(
-					`Invalid JSON format for applications input: ${
+					`Invalid JSON format for applications config input: ${
 						error instanceof Error ? error.message : "Unknown error"
 					}`,
 				);


### PR DESCRIPTION
Add application config as input. Make it possible to override applications environments with preview environments based on url input. 