### PR TITLE
Update run trigger format

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39410,7 +39410,7 @@ async function run() {
         if (applicationsInputParsed) {
             // Transform the old Record format to the new array format for the API
             const applications = Object.entries(applicationsInputParsed).map(([appId, config]) => ({
-                applicationShortId: `app+${appId}`,
+                applicationShortId: appId,
                 environment: config.environment,
                 // devicePresetShortId can be added here in the future
             }));

--- a/dist/index.js
+++ b/dist/index.js
@@ -39371,14 +39371,14 @@ async function run() {
         const apiToken = core.getInput("api_token", { required: true });
         const testPlanShortId = parseTestPlanShortId(core.getInput("test_plan_short_id"));
         const applicationsInput = core.getInput("applications_config");
-        let applications;
+        let applicationsInputParsed;
         if (applicationsInput) {
             try {
                 const parsed = JSON.parse(applicationsInput);
                 // Only accept wrapped format with "applications" property
                 if (parsed.applications) {
-                    applications = parsed.applications;
-                    core.debug(`Parsed applications: ${JSON.stringify(applications)}`);
+                    applicationsInputParsed = parsed.applications;
+                    core.debug(`Parsed applications: ${JSON.stringify(applicationsInputParsed)}`);
                 }
                 else {
                     core.setFailed('Applications config input must contain an "applications" property at the root level');
@@ -39407,8 +39407,14 @@ async function run() {
             core.debug(`Including test plan: ${testPlanShortId}`);
             payload.testPlanShortId = testPlanShortId;
         }
-        if (applications) {
-            core.debug(`Including application overrides for ${Object.keys(applications).length} applications`);
+        if (applicationsInputParsed) {
+            // Transform the old Record format to the new array format for the API
+            const applications = Object.entries(applicationsInputParsed).map(([appId, config]) => ({
+                applicationShortId: `app+${appId}`,
+                environment: config.environment,
+                // devicePresetShortId can be added here in the future
+            }));
+            core.debug(`Including application overrides for ${applications.length} applications`);
             payload.applications = applications;
         }
         core.debug(`Triggering QA.tech run with payload: ${JSON.stringify(payload)}`);
@@ -39418,7 +39424,7 @@ async function run() {
             core.setOutput("run_short_id", result.run.shortId);
             core.setOutput("run_url", result.run.url);
             core.info(`QA.tech run started with ID: ${result.run.shortId}${result.run.testPlan
-                ? `, Test Plan: ${result.run.testPlan.name} with ID: ${result.run.testPlan.short_id}`
+                ? `, Test Plan: ${result.run.testPlan.name} with ID: ${result.run.testPlan.shortId}`
                 : ""}`);
             core.info(`View run at: ${result.run.url}`);
             if (blocking) {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -117,7 +117,7 @@ describe("GitHub Action", () => {
 				testCount: 10,
 				testPlan: {
 					name: "My test plan",
-					short_id: "testPlan",
+					shortId: "testPlan",
 				},
 			},
 		};
@@ -197,7 +197,7 @@ describe("GitHub Action", () => {
 				testCount: 10,
 				testPlan: {
 					name: "Test 1",
-					short_id: "test1",
+					shortId: "test1",
 				},
 			},
 		};
@@ -234,7 +234,7 @@ describe("GitHub Action", () => {
 				testCount: 10,
 				testPlan: {
 					name: "Test plan 123",
-					short_id: "test-plan-123",
+					shortId: "test-plan-123",
 				},
 			},
 		};
@@ -379,7 +379,7 @@ describe("GitHub Action", () => {
 
 		const mockStatusResponse = {
 			id: "test-id",
-			short_id: "short-id",
+			shortId: "short-id",
 			status: "COMPLETED" as const,
 			result: "PASSED" as const,
 		};
@@ -421,7 +421,7 @@ describe("GitHub Action", () => {
 
 		const mockStatusResponse = {
 			id: "test-id",
-			short_id: "short-id",
+			shortId: "short-id",
 			status: "COMPLETED" as const,
 			result: "FAILED" as const,
 		};
@@ -453,14 +453,14 @@ describe("GitHub Action", () => {
 				testCount: 10,
 				testPlan: {
 					name: "Test Plan Name",
-					short_id: "test-plan-123",
+					shortId: "test-plan-123",
 				},
 			},
 		};
 
 		const mockStatusResponse = {
 			id: "test-id",
-			short_id: "short-id",
+			shortId: "short-id",
 			status: "COMPLETED" as const,
 			result: "PASSED" as const,
 		};
@@ -502,14 +502,14 @@ describe("GitHub Action", () => {
 
 		const runningStatus = {
 			id: "test-id",
-			short_id: "short-id",
+			shortId: "short-id",
 			status: "RUNNING" as const,
 			result: null,
 		};
 
 		const completedStatus = {
 			id: "test-id",
-			short_id: "short-id",
+			shortId: "short-id",
 			status: "COMPLETED" as const,
 			result: "PASSED" as const,
 		};

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -588,7 +588,7 @@ describe("GitHub Action", () => {
 			expect.objectContaining({
 				applications: [
 					{
-						applicationShortId: "app+ONdgMD",
+						applicationShortId: "app_ONdgMD",
 						environment: {
 							url: "https://app.bugduck.tech?release=test1233",
 						},
@@ -651,7 +651,7 @@ describe("GitHub Action", () => {
 			expect.objectContaining({
 				applications: [
 					{
-						applicationShortId: "app+ONdgMD",
+						applicationShortId: "app_ONdgMD",
 						environment: {
 							url: "https://app.bugduck.tech?release=test1233",
 							name: "test1233",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -586,13 +586,14 @@ describe("GitHub Action", () => {
 			"https://api.qa.tech/v1/run",
 			"test-token-12345",
 			expect.objectContaining({
-				applications: {
-					ONdgMD: {
+				applications: [
+					{
+						applicationShortId: "app+ONdgMD",
 						environment: {
 							url: "https://app.bugduck.tech?release=test1233",
 						},
 					},
-				},
+				],
 			}),
 		);
 		expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");
@@ -648,14 +649,15 @@ describe("GitHub Action", () => {
 			"https://api.qa.tech/v1/run",
 			"test-token-12345",
 			expect.objectContaining({
-				applications: {
-					ONdgMD: {
+				applications: [
+					{
+						applicationShortId: "app+ONdgMD",
 						environment: {
 							url: "https://app.bugduck.tech?release=test1233",
 							name: "test1233",
 						},
 					},
-				},
+				],
 			}),
 		);
 		expect(core.setOutput).toHaveBeenCalledWith("run_created", "true");

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -541,7 +541,7 @@ describe("GitHub Action", () => {
 	it("should handle applications with only url field", async () => {
 		const applicationsJson = JSON.stringify({
 			applications: {
-				ONdgMD: {
+				app_ONdgMD: {
 					environment: {
 						url: "https://app.bugduck.tech?release=test1233",
 					},
@@ -603,7 +603,7 @@ describe("GitHub Action", () => {
 	it("should handle applications with both url and name fields", async () => {
 		const applicationsJson = JSON.stringify({
 			applications: {
-				ONdgMD: {
+				app_ONdgMD: {
 					environment: {
 						url: "https://app.bugduck.tech?release=test1233",
 						name: "test1233",

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -8,7 +8,7 @@ export interface RunDetails {
 	testCount: number;
 	testPlan: {
 		name: string;
-		short_id: string;
+		shortId: string;
 	} | null;
 }
 
@@ -40,7 +40,7 @@ export interface ApiResponse {
 
 export interface RunStatus {
 	id: string;
-	short_id: string;
+	shortId: string;
 	status: "INITIATED" | "RUNNING" | "COMPLETED" | "ERROR" | "CANCELLED";
 	result: "PASSED" | "FAILED" | "SKIPPED" | null;
 }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -19,15 +19,18 @@ export interface Payload {
 	commitHash: string;
 	repository: `${string}/${string}`;
 	testPlanShortId?: string;
-	applications?: Record<
-		string,
-		{
-			environment: {
-				url: string;
-				name?: string;
-			};
-		}
-	>;
+	applications?: Array<{
+		applicationShortId: string;
+		environment?:
+			| {
+					url: string;
+					name?: string;
+			  }
+			| {
+					shortId: string;
+			  };
+		devicePresetShortId?: string;
+	}>;
 }
 
 export interface ApiResponse {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export async function run(): Promise<void> {
 		);
 
 		const applicationsInput = core.getInput("applications_config");
-		let applications:
+		let applicationsInputParsed:
 			| Record<string, { environment: { url: string; name?: string } }>
 			| undefined;
 
@@ -49,8 +49,10 @@ export async function run(): Promise<void> {
 				const parsed = JSON.parse(applicationsInput);
 				// Only accept wrapped format with "applications" property
 				if (parsed.applications) {
-					applications = parsed.applications;
-					core.debug(`Parsed applications: ${JSON.stringify(applications)}`);
+					applicationsInputParsed = parsed.applications;
+					core.debug(
+						`Parsed applications: ${JSON.stringify(applicationsInputParsed)}`,
+					);
 				} else {
 					core.setFailed(
 						'Applications config input must contain an "applications" property at the root level',
@@ -88,11 +90,18 @@ export async function run(): Promise<void> {
 			payload.testPlanShortId = testPlanShortId;
 		}
 
-		if (applications) {
+		if (applicationsInputParsed) {
+			// Transform the old Record format to the new array format for the API
+			const applications: NonNullable<Payload["applications"]> = Object.entries(
+				applicationsInputParsed,
+			).map(([appId, config]) => ({
+				applicationShortId: `app+${appId}`,
+				environment: config.environment,
+				// devicePresetShortId can be added here in the future
+			}));
+
 			core.debug(
-				`Including application overrides for ${
-					Object.keys(applications).length
-				} applications`,
+				`Including application overrides for ${applications.length} applications`,
 			);
 			payload.applications = applications;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export async function run(): Promise<void> {
 			core.info(
 				`QA.tech run started with ID: ${result.run.shortId}${
 					result.run.testPlan
-						? `, Test Plan: ${result.run.testPlan.name} with ID: ${result.run.testPlan.short_id}`
+						? `, Test Plan: ${result.run.testPlan.name} with ID: ${result.run.testPlan.shortId}`
 						: ""
 				}`,
 			);

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export async function run(): Promise<void> {
 			const applications: NonNullable<Payload["applications"]> = Object.entries(
 				applicationsInputParsed,
 			).map(([appId, config]) => ({
-				applicationShortId: `app+${appId}`,
+				applicationShortId: appId,
 				environment: config.environment,
 				// devicePresetShortId can be added here in the future
 			}));


### PR DESCRIPTION
Context: the Record<string app short iD, approverridestuff> does not work nicely with typespec, so this PR updates the parameter to take a more conventional array of objects that include the app short ID within them. This action updates the format of the payload passed to the new API to match.

This does not change the _action_ parameters themselves, so the user would not need to rework their action body format once they update the version. It only updates how we invoke our own API to start a run.

Accompanying qatech monorepo PR: https://github.com/QAdottech/qatech/pull/6382